### PR TITLE
Box plot bug fixes

### DIFF
--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/BoxPlot.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/BoxPlot.tsx
@@ -10,19 +10,19 @@ import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_colo
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import { createContainer } from './wrapper';
 
-const formatDate = (dateString) => {
-  if (!dateString) return ''; // Return empty string if dateString is undefined or null
-  const date = new Date(dateString);
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  }).format(date);
-};
+// const formatDate = (dateString) => {
+//   if (!dateString) return ''; // Return empty string if dateString is undefined or null
+//   const date = new Date(dateString);
+//   return new Intl.DateTimeFormat('en-US', {
+//     year: 'numeric',
+//     month: 'short',
+//     day: 'numeric',
+//     hour: '2-digit',
+//     minute: '2-digit'
+//   }).format(date);
+// };
 
-const formatNumber = (number, decimals = 2) => {
+const formatNumber = (number, decimals = 3) => {
   if (number == null || isNaN(number)) {
     return ''; // Return an empty string or some default value if the value is not a number
   }
@@ -120,7 +120,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             cursorDimension="x"
             labels={({ datum }) => {
               if (datum && datum.y != null) {
-                return `${formatDate(datum.x)}: ${formatNumber(datum.y)}`;
+                return `${datum.x}: ${formatNumber(datum.y)}`;
               } else {
                 return 'no data';
               }
@@ -130,7 +130,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
                 flyoutHeight={130}
                 flyoutWidth={170}
                 constrainToVisibleArea
-                labelComponent={<HtmlLegendContent title={(datum) => formatDate(datum?.x ?? '')} />}
+                labelComponent={<HtmlLegendContent title={(datum) => datum?.x ?? ''} />}
               />
             }
             mouseFollowTooltips
@@ -140,7 +140,6 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              maxWidth: '150px',
               padding: 1
             }}
           />
@@ -163,7 +162,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         width={600}
       >
         <ChartAxis
-          tickFormat={(tick) => formatDate(tick)}
+          tickFormat={(tick) => tick}
           style={{
             tickLabels: {
               angle: -45,

--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/CostBoxPlotCharts.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/CostBoxPlotCharts.tsx
@@ -1,71 +1,116 @@
 import React from 'react';
 import { ChartThemeColor } from '@patternfly/react-charts';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import BoxPlot from './BoxPlot';
 
-export const convertMmrData = (data: any[]) => {
+// conversion values needs to be fixed here as well
+export const convertMmrData = (day, data: any[]) => {
+  // let displaykey =  day === 'short_term' ? key.split(' ')[1] : key.split(' ')[0];
+
   return data?.map((item) => ({
     ...item,
+    x: day === 'short_term' ? item.x.substring(11, 16) : item.x.split('T')[0],
     y: item?.y?.map((value: number) => value / 1024 ** 3)
   }));
 };
 
-export const getMaxValueFromConvertedData = (data: any[],cpuTrue) => {
-  const convertedData = cpuTrue?  data : convertMmrData(data);
+export const getMaxValueFromConvertedData = (day, data: any[], requestValue, cpuTrue) => {
+  const convertedData = cpuTrue ? data : convertMmrData(day, data);
   const allValues = convertedData.flatMap((item) => item.y || []);
 
-  const maxValue = Math.max(...allValues);
-  const minVal = Math.min(...allValues)
-  return {maxValue, minVal};
+  // once buffer value is known we can add that here
+  const maxV = Math.max(...allValues, requestValue);
+  const buffer = 0.1 * maxV;
+  const maxValue = Math.max(...allValues, requestValue) + buffer;
+  const minVal = Math.min(...allValues, requestValue) - buffer;
+  return { maxValue, minVal };
 };
 
-const CostBoxPlotCharts = (props: { boxPlotData; limitRequestData }) => {
+const CostBoxPlotCharts = (props: { boxPlotData; showCostBoxPlot; day; limitRequestData }) => {
   const cpuDataLimit = props.limitRequestData?.limits?.cpu?.amount;
   const cpuDataRequest = props.limitRequestData?.requests?.cpu?.amount;
 
-  const mmrDataLimit = (props.limitRequestData?.limits?.memory?.amount)/1024 ** 2;
-  const mmrDataRequest = (props.limitRequestData?.requests?.memory?.amount)/1024 ** 2;
-console.log(mmrDataLimit)
-console.log(mmrDataRequest)
+  // this needs to be fixed the conversion values
+  const mmrDataLimit = props.limitRequestData?.limits?.memory?.amount / 1024 ** 3;
+  const mmrDataRequest = props.limitRequestData?.requests?.memory?.amount / 1024 ** 3;
+
   const cpulimitsChart = props.boxPlotData?.cpu?.map((dict) => {
-    return { ...dict, y: cpuDataLimit };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0],
+      y: cpuDataLimit
+    };
   });
   const cpurequestChart = props.boxPlotData?.cpu?.map((dict) => {
-    return { ...dict, y: cpuDataRequest };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0],
+      y: cpuDataRequest
+    };
   });
 
   const mmrlimitsChart = props.boxPlotData?.mmr?.map((dict) => {
-    return { ...dict, y: mmrDataLimit };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0],
+      y: mmrDataLimit
+    };
   });
   const mmrrequestChart = props.boxPlotData?.mmr?.map((dict) => {
-    return { ...dict, y: mmrDataRequest };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0],
+      y: mmrDataRequest
+    };
   });
-  
-  const { maxValue: maxcpuValue, minVal: mincpuVal } = props.boxPlotData?.cpu  ? getMaxValueFromConvertedData(props.boxPlotData?.cpu, true)   : { maxValue: 1, minVal: 0 };
-  
-  console.log(maxcpuValue, mincpuVal)
-  const { maxValue, minVal } =  props.boxPlotData?.mmr ? getMaxValueFromConvertedData(props.boxPlotData?.mmr, false):{ maxValue: 1, minVal: 0 }
-  const ab = convertMmrData(props.boxPlotData?.mmr);
+
+  const { maxValue: maxcpuValue, minVal: mincpuVal } = props.boxPlotData?.cpu
+    ? getMaxValueFromConvertedData(props.day, props.boxPlotData?.cpu, cpuDataRequest, true)
+    : { maxValue: 1, minVal: 0 };
+
+  // console.log(maxcpuValue, mincpuVal);
+  const { maxValue, minVal } = props.boxPlotData?.mmr
+    ? getMaxValueFromConvertedData(props.day, props.boxPlotData?.mmr, mmrDataRequest, false)
+    : { maxValue: 1, minVal: 0 };
+
+  console.log(maxcpuValue, mincpuVal);
+  console.log(maxValue, minVal);
+  const mmr_cost_boxplot_data = convertMmrData(props.day, props.boxPlotData?.mmr);
+  const cpu_cost_boxplot_data = props.boxPlotData?.cpu?.map((dict) => {
+    return { ...dict, x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0] };
+  });
 
   // cpu and mmr box plots for cost
   return (
-    <Flex direction={{ default: 'row' }}>
-      <FlexItem style={{ width: '50%' }}>
+    <Grid hasGutter>
+      <GridItem span={6} rowSpan={8}>
+        {props.showCostBoxPlot ? (
+          <BoxPlot
+            data={cpu_cost_boxplot_data}
+            limitsThresholdChartData={cpulimitsChart}
+            requestThresholdChartData={cpurequestChart}
+            chartTitle="CPU"
+            ariaDesc="CPU"
+            domain={{ y: [mincpuVal, maxcpuValue] }}
+            themeColor={ChartThemeColor.orange}
+            legendData={[{ name: 'CPU' }]}
+          />
+        ) : (
+          <BoxPlot
+            data={cpu_cost_boxplot_data}
+            limitsThresholdChartData={cpulimitsChart}
+            requestThresholdChartData={cpurequestChart}
+            chartTitle="CPU"
+            ariaDesc="CPU"
+            domain={{ y: [0, 1] }}
+            themeColor={ChartThemeColor.orange}
+            legendData={[{ name: 'CPU' }]}
+          />
+        )}
+      </GridItem>
+      <GridItem span={6} rowSpan={8}>
         <BoxPlot
-          data={props.boxPlotData?.cpu}
-          limitsThresholdChartData={cpulimitsChart}
-          requestThresholdChartData={cpurequestChart}
-          chartTitle="CPU"
-          ariaDesc="CPU"
-          domain={{ y: [mincpuVal, maxcpuValue] }}
-          themeColor={ChartThemeColor.orange}
-          legendData={[{ name: 'CPU' }]}
-        />
-      </FlexItem>
-
-      <FlexItem>
-        <BoxPlot
-          data={ab}
+          data={mmr_cost_boxplot_data}
           limitsThresholdChartData={mmrlimitsChart}
           requestThresholdChartData={mmrrequestChart}
           chartTitle="Memory"
@@ -74,8 +119,8 @@ console.log(mmrDataRequest)
           themeColor={ChartThemeColor.orange}
           legendData={[{ name: 'Memory' }]}
         />
-      </FlexItem>
-    </Flex>
+      </GridItem>
+    </Grid>
   );
 };
 

--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/PerfBoxPlotCharts.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/BoxPlots/PerfBoxPlotCharts.tsx
@@ -1,69 +1,100 @@
 import React, { useState } from 'react';
-import {
-  ChartThemeColor,
-
-} from '@patternfly/react-charts';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { ChartThemeColor } from '@patternfly/react-charts';
+import { Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
 import BoxPlot from './BoxPlot';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import { getMaxValueFromConvertedData, convertMmrData } from './CostBoxPlotCharts';
 
-const PerfBoxPlotCharts = (props: { boxPlotData; limitRequestData }) => {
+const PerfBoxPlotCharts = (props: { boxPlotData; day; showPerfBoxPlot; limitRequestData }) => {
   const cpuDataLimit = props.limitRequestData?.limits?.cpu?.amount;
   const cpuDataRequest = props.limitRequestData?.requests?.cpu?.amount;
 
-  const mmrDataLimit = (props.limitRequestData?.limits?.memory?.amount)/1024 ** 2;
-  const mmrDataRequest = (props.limitRequestData?.requests?.memory?.amount)/1024 ** 2;
-console.log(mmrDataLimit)
-console.log(mmrDataRequest)
+  const mmrDataLimit = props.limitRequestData?.limits?.memory?.amount / 1024 ** 2;
+  const mmrDataRequest = props.limitRequestData?.requests?.memory?.amount / 1024 ** 2;
+
   const cpulimitsChart = props.boxPlotData?.cpu?.map((dict) => {
-    return { ...dict, y: cpuDataLimit };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16): dict.x.split('T')[0],
+      y: cpuDataLimit
+    };
   });
   const cpurequestChart = props.boxPlotData?.cpu?.map((dict) => {
-    return { ...dict, y: cpuDataRequest };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16): dict.x.split('T')[0],
+      y: cpuDataRequest
+    };
   });
 
   const mmrlimitsChart = props.boxPlotData?.mmr?.map((dict) => {
-    return { ...dict, y: mmrDataLimit };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16): dict.x.split('T')[0],
+      y: mmrDataLimit
+    };
   });
+
   const mmrrequestChart = props.boxPlotData?.mmr?.map((dict) => {
-    return { ...dict, y: mmrDataRequest };
+    return {
+      ...dict,
+      x: props.day === 'short_term' ? dict.x.substring(11, 16): dict.x.split('T')[0],
+      y: mmrDataRequest
+    };
   });
 
-  const { maxValue: maxcpuValue, minVal: mincpuVal } = props.boxPlotData?.cpu  ? getMaxValueFromConvertedData(props.boxPlotData?.cpu, true)   : { maxValue: 1, minVal: 0 };
+  const { maxValue: maxcpuValue, minVal: mincpuVal } = props.boxPlotData?.cpu
+    ? getMaxValueFromConvertedData(props.day, props.boxPlotData?.cpu, cpuDataRequest, true)
+    : { maxValue: 1, minVal: 0 };
 
-  const { maxValue, minVal } =  props.boxPlotData?.mmr ? getMaxValueFromConvertedData(props.boxPlotData?.mmr, false):{ maxValue: 1, minVal: 0 }
-  const ab = convertMmrData(props.boxPlotData?.mmr)
+  const { maxValue, minVal } = props.boxPlotData?.mmr
+    ? getMaxValueFromConvertedData(props.day, props.boxPlotData?.mmr, mmrDataRequest, false)
+    : { maxValue: 1, minVal: 0 };
 
+  const mmr_perf_boxplot_data = convertMmrData(props.day, props.boxPlotData?.mmr);
+  const cpu_perf_boxplot_data = props.boxPlotData?.cpu?.map((dict) => {
+    return { ...dict, x: props.day === 'short_term' ? dict.x.substring(11, 16) : dict.x.split('T')[0] };
+  });
   // cpu and mmr box plots for performance
   return (
-    <Flex direction={{ default: 'row' }} >
-      <FlexItem style={{ width: '50%' }}>
-      <BoxPlot
-        data={props.boxPlotData?.cpu}
-        limitsThresholdChartData={cpulimitsChart}
-        requestThresholdChartData={cpurequestChart}
-        chartTitle="CPU"
-        ariaDesc="CPU"
-        domain={{ y: [mincpuVal, maxcpuValue] }}
-        themeColor={ChartThemeColor.orange}
-        legendData={[{ name: 'CPU' }]}
-      />
-</FlexItem>
-
-<FlexItem>
-      <BoxPlot
-        data={ab}
-        limitsThresholdChartData={mmrlimitsChart}
-        requestThresholdChartData={mmrrequestChart}
-        chartTitle="Memory"
-        ariaDesc="Memory"
-        domain={{ y: [minVal, maxValue] }}
-        themeColor={ChartThemeColor.orange}
-        legendData={[{ name: 'Memory' }]}
-      />
-    </FlexItem>
-    </Flex>
+    <Grid hasGutter>
+      <GridItem span={6} rowSpan={8}>
+     {props.showPerfBoxPlot?
+        <BoxPlot
+          data={cpu_perf_boxplot_data}
+          limitsThresholdChartData={cpulimitsChart}
+          requestThresholdChartData={cpurequestChart}
+          chartTitle="CPU"
+          ariaDesc="CPU"
+          domain={{ y: [mincpuVal, maxcpuValue] }}
+          themeColor={ChartThemeColor.orange}
+          legendData={[{ name: 'CPU' }]}
+        /> :
+        <BoxPlot
+          data={cpu_perf_boxplot_data}
+          limitsThresholdChartData={cpulimitsChart}
+          requestThresholdChartData={cpurequestChart}
+          chartTitle="CPU"
+          ariaDesc="CPU"
+          domain={{ y: [0,1] }}
+          themeColor={ChartThemeColor.orange}
+          legendData={[{ name: 'CPU' }]}
+        />
+     }
+      </GridItem>
+      <GridItem span={6} rowSpan={8}>
+        <BoxPlot
+          data={mmr_perf_boxplot_data}
+          limitsThresholdChartData={mmrlimitsChart}
+          requestThresholdChartData={mmrrequestChart}
+          chartTitle="Memory"
+          ariaDesc="Memory"
+          domain={{ y: [minVal, maxValue] }}
+          themeColor={ChartThemeColor.orange}
+          legendData={[{ name: 'Memory' }]}
+        />
+      </GridItem>
+    </Grid>
   );
 };
 

--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/CostDetails.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/CostDetails.tsx
@@ -50,9 +50,8 @@ export const MemoryFormat = (number) => {
 export const MemoryFormatP = (number) => {
   let parsedNo = parseFloat(number);
   if (!parsedNo) return '';
-  console.log(addPlusSign(Math.round(parsedNo / 1024 ** 3)))
-  return addPlusSign(Math.round(parsedNo / 1024 ** 3))
-
+  console.log(addPlusSign(Math.round(parsedNo / 1024 ** 3)));
+  return addPlusSign(Math.round(parsedNo / 1024 ** 3));
 };
 
 export const NumberFormatP = (number) => {
@@ -79,6 +78,7 @@ const NumberFormat = (number) => {
 const CostDetails = (props: { recommendedData; currentData; chartData; day; endtime; displayChart; boxPlotData }) => {
   const limits = props.recommendedData[0]?.recommendation_engines?.cost?.config?.limits;
   const config_keys = limits ? Object.keys(limits) : [];
+  const [showCostBoxPlot, setShowCostBoxPlot] = useState(true);
 
   let gpu_val;
   let nvidiaKey = config_keys.find((key) => key.toLowerCase().includes('nvidia'));
@@ -101,24 +101,25 @@ const CostDetails = (props: { recommendedData; currentData; chartData; day; endt
   requests: 
     memory: "${MemoryFormat(
       props.recommendedData[0]?.recommendation_engines?.cost?.config?.requests?.memory?.amount
-    )}"    # ${MemoryFormatP(props.recommendedData[0]?.recommendation_engines?.cost?.variation?.requests?.memory?.amount)
-    }
+    )}"    # ${MemoryFormatP(
+      props.recommendedData[0]?.recommendation_engines?.cost?.variation?.requests?.memory?.amount
+    )}
     cpu: "${NumberFormat(
       props.recommendedData[0]?.recommendation_engines?.cost?.config?.requests?.cpu?.amount
-    )}"      # ${
-      NumberFormatP(props.recommendedData[0]?.recommendation_engines?.cost?.variation?.requests?.cpu?.amount)
-    }
+    )}"      # ${NumberFormatP(
+      props.recommendedData[0]?.recommendation_engines?.cost?.variation?.requests?.cpu?.amount
+    )}
   limits: 
     memory: "${MemoryFormat(
       props.recommendedData[0]?.recommendation_engines?.cost?.config?.limits?.memory?.amount
-    )}"    # ${
-      MemoryFormatP(props.recommendedData[0]?.recommendation_engines?.cost?.variation?.limits?.memory.amount)
-    }  
+    )}"    # ${MemoryFormatP(
+      props.recommendedData[0]?.recommendation_engines?.cost?.variation?.limits?.memory.amount
+    )}  
     cpu: "${NumberFormat(
       props.recommendedData[0]?.recommendation_engines?.cost?.config?.limits?.cpu?.amount
-    )}"      # ${
-      NumberFormatP(props.recommendedData[0]?.recommendation_engines?.cost?.variation?.limits?.cpu?.amount)
-    }`;
+    )}"      # ${NumberFormatP(
+      props.recommendedData[0]?.recommendation_engines?.cost?.variation?.limits?.cpu?.amount
+    )}`;
 
   // Code for Alert / Notifications
 
@@ -132,11 +133,14 @@ const CostDetails = (props: { recommendedData; currentData; chartData; day; endt
 
   const utilizationAlert = (recommendation) => {
     const notifications = recommendation[0]?.recommendation_engines?.cost?.notifications;
+    if (notifications?.hasOwnProperty(323001)) {
+      setShowCostBoxPlot(false);
+    }
     try {
       if (!notifications) {
         console.warn('No notifications found.');
         return;
-      } 
+      }
       const newAlerts: Alert[] = [];
       Object.values(notifications).forEach((notification: any, index) => {
         const message = `${notification.code} - ${notification.message}`;
@@ -190,13 +194,16 @@ const CostDetails = (props: { recommendedData; currentData; chartData; day; endt
           </Card>
         </GridItem>
       </Grid>
-      {props.boxPlotData && props.recommendedData[0]?.recommendation_engines?.cost?.config ?
-      <CostBoxPlotCharts
-        boxPlotData={props.boxPlotData}
-        limitRequestData={props.recommendedData[0]?.recommendation_engines?.cost?.config}
-      />
-: <div> No data to plot box</div>
-}
+      {props.boxPlotData && props.recommendedData[0]?.recommendation_engines?.cost?.config ? (
+        <CostBoxPlotCharts
+          boxPlotData={props.boxPlotData}
+          showCostBoxPlot={showCostBoxPlot}
+          day={props.day} 
+          limitRequestData={props.recommendedData[0]?.recommendation_engines?.cost?.config}
+        />
+      ) : (
+        <div> No data to plot box</div>
+      )}
       {props.displayChart && <CostHistoricCharts chartData={props.chartData} day={props.day} endtime={props.endtime} />}
     </PageSection>
   );

--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/PerfDetails.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/RecommendationComponents/PerfDetails.tsx
@@ -35,6 +35,7 @@ const PerfDetails = (props: {
 }) => {
   const limits = props.recommendedData[0]?.recommendation_engines?.performance?.config?.limits;
   const config_keys = limits ? Object.keys(limits) : [];
+  const [showPerfBoxPlot, setShowPerfBoxPlot] = useState(true);
 
   let gpu_val;
   let nvidiaKey = config_keys.find((key) => key.toLowerCase().includes('nvidia'));
@@ -120,6 +121,10 @@ const PerfDetails = (props: {
 
   const utilizationAlert = (recommendation) => {
     const notifications = recommendation[0]?.recommendation_engines?.performance?.notifications;
+    if (notifications?.hasOwnProperty(323001)) {
+      setShowPerfBoxPlot(false);
+    }
+    console.log("perfn", notifications)
     try {
       if (!notifications) {
         console.warn('No notifications found.');
@@ -186,6 +191,8 @@ const PerfDetails = (props: {
       </Grid>
       <PerfBoxPlotCharts
         boxPlotData={props.boxPlotData}
+        showPerfBoxPlot={showPerfBoxPlot}
+        day={props.day} 
         limitRequestData={props.recommendedData[0]?.recommendation_engines?.performance?.config}
       />
       {props.displayChart && <PerfHistoricCharts chartData={props.chartData} day={props.day} endtime={props.endtime} />}{' '}

--- a/src/app/HorizontalNav/HorizontalNav.tsx
+++ b/src/app/HorizontalNav/HorizontalNav.tsx
@@ -76,10 +76,10 @@ const HorizontalNav = () => {
         {clusterStatus === false ? (
           <Popover
             aria-label="Basic popover"
-            headerContent={<div>No Minikube Connection.</div>}
+            headerContent={<div>No Kubernetes Connection.</div>}
             bodyContent={
               <div>
-                <b>Minikube connection is pre requisite for autotune setup.</b>
+                <b>Kubernetes connection is pre requisite for setting up Kruize.</b>
               </div>
             }
           >
@@ -88,12 +88,12 @@ const HorizontalNav = () => {
         ) : (
           <Popover
             aria-label="Basic popover"
-            headerContent={<div>Connected to Minikube Cluster!</div>}
+            headerContent={<div>Connected to Kubernetes Cluster!</div>}
             bodyContent={
               <div>
                 <b>Cluster Information </b>
                 <br />
-                <label>Minikube URL : http://{ip}</label>
+                <label>Kubernetes URL : http://{ip}</label>
 
                 <div>
                   <br />


### PR DESCRIPTION
The commit contains the following bug fixes : 
1. Three digits format for cpu plots
2. Y domain
YMAX: Max (boxplots max , recommendation val) + buffer
YMIN: Min (recommendation value,  box plots min)  - buffer

buffer = 10% * max
 Add plot values in these ranges and check if looks good 

3. X-axis timestamps similar to crc UX right
4. Do not generate box plots for CPU if CPU is idle (idle notification = 323001, < 1millicore of usage is present). IOW this should be an empty box plot. ( with time stamp on x axis)
5. The memory box plot goes under the cpu box plot in some cases, would be good to have them on the same line always
Make same changes on both cost and performance side
