### PR TITLE
Fixing Dropdown to Exclude Namespace Experiments

### DIFF
--- a/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/UsecaseSelection.tsx
+++ b/src/app/Analytics/LocalMonitoring/RecommendationsForLocalMonitoring/RemoteMonitoring/UsecaseSelection.tsx
@@ -46,9 +46,12 @@ const UsecaseSelection = (props: { endTimeArray; setEndTimeArray; SREdata; setSR
     const data = await response.json();
     const arr: any = ['Select Experiment Name'];
 
-    data.map((element, index) => {
-      arr.push(element.experiment_name);
+    data.forEach((element) => {
+      if (element.experiment_type === 'container') {
+        arr.push(element.experiment_name);
+      }
     });
+    
     setExpData(arr.sort());
   };
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the dropdown for list experiments to exclude namespace experiments and display only container type experiments. 

Detailed Issue - https://github.com/kruize/kruize-ui/issues/205

Loom Video - loom.com/share/bc162548cc8049f5b6e5527a546890f9
