### PR TITLE
[UI] Add metadata_profile field in payload JSONs

### DIFF
--- a/src/app/Analytics/LocalMonitoring/GenerateJSON/createExperimentYAML.tsx
+++ b/src/app/Analytics/LocalMonitoring/GenerateJSON/createExperimentYAML.tsx
@@ -4,6 +4,7 @@ export default `[
       "experiment_name": "subsitute_experiment_name",
       "cluster_name": "subsitute_cluster_name",
       "performance_profile": "resource-optimization-local-monitoring",
+      "metadata_profile": "cluster-metadata-local-monitoring",
       "mode": "monitor",
       "target_cluster": "local",
       "kubernetes_objects": [

--- a/src/store/actions/DataSourceActionCreator.tsx
+++ b/src/store/actions/DataSourceActionCreator.tsx
@@ -24,7 +24,9 @@ export const importDataSourceMetaData = (dataSourceName: string) => async dispat
     try {
         const payload = {
             version: 'v1.0',
-            datasource_name: dataSourceName
+            datasource_name: dataSourceName,
+            metadata_profile: "cluster-metadata-local-monitoring",
+            measurement_duration: "15mins"
         };
         
         const response = await fetch(importDataSourcesMetadataURL(), {


### PR DESCRIPTION
This PR adds new added `metadata_profile` and `measurement_duration` fields in below REST API payloads in Kruize UI 

- POST /dsmetadata API 
```
{
  version: 'v1.0',
  datasource_name: dataSourceName,
  metadata_profile: "cluster-metadata-local-monitoring",
  measurement_duration: "15mins"
}
```
- POST /createExperiment API 
```
{
  "version": "v2.0",
  "experiment_name": "subsitute_experiment_name",
  "cluster_name": "subsitute_cluster_name",
  "performance_profile": "resource-optimization-local-monitoring",
  "metadata_profile": "cluster-metadata-local-monitoring",
  "mode": "monitor",
  "target_cluster": "local",
  ....
}
```

Verified using Kruize demos PR 128 
` ./local_monitoring_demo.sh -c kind -i quay.io/shbirada/temp:0.5 -u quay.io/shbirada/pr_238:0.5_ui -f`


UI changes demo: https://www.loom.com/share/28703939d1254859b23069871a3ea42e?sid=0d4207e5-15ed-480b-a167-7de68c100622